### PR TITLE
Removing camel casing for case-sensitive systems

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 var shortcode = require('shortcode-parser'),
-    each      = require('lodash.forEach'),
+    each      = require('lodash.foreach'),
     merge     = require('lodash.merge'),
     plugin;
 


### PR DESCRIPTION
Some operating systems (like the flavors of Linux that Heroku and Travis both run) are case-insensitive. When requiring `lodash.forEach`, they'll throw an error, because the string isn't identical to the dependency's key in `package.json`.

This PR resolves the issue, which is tested and running here:

Fail:
https://travis-ci.org/jonlong/static-site/builds/40857160#L384-L396

Pass: 
https://travis-ci.org/jonlong/static-site/builds/40905541#L247-L250
