### PR TITLE
Custom open / close tags

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2,9 +2,10 @@
 var ShortcodeParser = require('meta-shortcodes'),
     each = require('lodash.forEach'),
     merge = require('lodash.merge'),
-    parser = new ShortcodeParser(),
     plugin;
 plugin = function(opts) {
+  opts.parserOpts = opts.parserOpts || null;
+  var parser = new ShortcodeParser(opts.parserOpts);
   var generated = false,
       generateShortcodes = (function(data) {
         if (!generated) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 var ShortcodeParser = require('meta-shortcodes'),
     each      = require('lodash.forEach'),
     merge     = require('lodash.merge'),
-    parser    = new ShortcodeParser(),
     plugin;
 
 
 plugin = function(opts) {
+	opts.parserOpts = opts.parserOpts || null;
+    var parser    = new ShortcodeParser(opts.parserOpts);
     // loop through all the registered shortcodes
     var generated = false,
         generateShortcodes = (data) => {
@@ -17,13 +18,13 @@ plugin = function(opts) {
                 });
                 generated = true;
             }
-        } 
+        }
 
     return (files, metalsmith, done) => {
         each(files, (file, path) => {
             if (!file.shortcodes) { return; }
             var cnt = file.contents.toString(),
-                data = merge({}, file, metalsmith.metadata()); 
+                data = merge({}, file, metalsmith.metadata());
 
             generateShortcodes(data);
 
@@ -39,7 +40,7 @@ plugin = function(opts) {
         });
         done();
     };
-};  
+};
 
 
 module.exports = plugin;

--- a/test/fixtures/expected/metadata-file/plain.txt
+++ b/test/fixtures/expected/metadata-file/plain.txt
@@ -1,2 +1,2 @@
-This should be 'Hello':  
+This should be 'Hello':
 Hello

--- a/test/fixtures/src/custom-tags/index.html
+++ b/test/fixtures/src/custom-tags/index.html
@@ -1,0 +1,7 @@
+---
+title: HTML
+shortcodes: true
+---
+<p>
+This shows a simple self enclosing shortcode in HTML: {{makro /}}
+</p>

--- a/test/fixtures/src/custom-tags/markdown.md
+++ b/test/fixtures/src/custom-tags/markdown.md
@@ -1,0 +1,5 @@
+---
+title: Markdown
+shortcodes: true
+---
+This shows a simple self enclosing shortcode in markdown: {{makro /}}

--- a/test/fixtures/src/custom-tags/plain.txt
+++ b/test/fixtures/src/custom-tags/plain.txt
@@ -1,0 +1,5 @@
+---
+title: Plain
+shortcodes: true
+---
+This shows a simple self enclosing shortcode in plain text: {{makro /}}

--- a/test/fixtures/src/metadata-file/plain.txt
+++ b/test/fixtures/src/metadata-file/plain.txt
@@ -3,5 +3,5 @@ title: Plain
 shortcodes: true
 test: 'Hello'
 ---
-This should be 'Hello':  
-[var test]
+This should be 'Hello':
+[var test/]

--- a/test/fixtures/src/metadata-global/plain.txt
+++ b/test/fixtures/src/metadata-global/plain.txt
@@ -2,5 +2,5 @@
 title: Plain
 shortcodes: true
 ---
-This should be 'Hello':  
-[var globalTest]
+This should be 'Hello':
+[var globalTest /]

--- a/test/fixtures/src/simple-self-closing/index.html
+++ b/test/fixtures/src/simple-self-closing/index.html
@@ -3,5 +3,5 @@ title: HTML
 shortcodes: true
 ---
 <p>
-This shows a simple self enclosing shortcode in HTML: [makro]
+This shows a simple self enclosing shortcode in HTML: [makro /]
 </p>

--- a/test/fixtures/src/simple-self-closing/markdown.md
+++ b/test/fixtures/src/simple-self-closing/markdown.md
@@ -2,4 +2,4 @@
 title: Markdown
 shortcodes: true
 ---
-This shows a simple self enclosing shortcode in markdown: [makro]
+This shows a simple self enclosing shortcode in markdown: [makro /]

--- a/test/fixtures/src/simple-self-closing/plain.txt
+++ b/test/fixtures/src/simple-self-closing/plain.txt
@@ -2,4 +2,4 @@
 title: Plain
 shortcodes: true
 ---
-This shows a simple self enclosing shortcode in plain text: [makro]
+This shows a simple self enclosing shortcode in plain text: [makro /]

--- a/test/test.js
+++ b/test/test.js
@@ -126,4 +126,28 @@ describe('metalsmith flexible shortcodes', function() {
             done();
         });
     });
+
+    it('allows custom elements', function(done){
+        msFactory('custom-tags', [{
+            opts: {
+            	parserOpts: {
+            		openPattern: '\\{{',
+            		closePattern: '\\}}'
+            	},
+                shortcodes: {
+                    makro: function() {
+                        return 'I\'m replaced :)';
+                    }
+                }
+            },
+            fn: require('..')
+        },
+        {
+            opts: {},
+            fn: require('metalsmith-markdown')
+        }], function() {
+            dirEqual(path.join(__dirname, 'tmp'), path.join(__dirname, 'fixtures/expected/simple-self-closing'));
+            done();
+        });
+    });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,7 @@ function msFactory(dir, plugins, done) {
     each(plugins, function(plugin) {
         ms.use(plugin.fn(plugin.opts));
     });
-    
+
     ms.destination('../../tmp');
 
     ms.build(function(err) {
@@ -45,7 +45,7 @@ describe('metalsmith flexible shortcodes', function() {
                 }
             },
             fn: require('..')
-        }, 
+        },
         {
             opts: {},
             fn: require('metalsmith-markdown')
@@ -66,7 +66,7 @@ describe('metalsmith flexible shortcodes', function() {
             opts: {
                 shortcodes: {
                     div: function(str) {
-                        return '<div>\n' + str + '\n</div>';
+                        return '<div>' + str + '</div>';
                     }
                 },
                 clean: true
@@ -83,9 +83,9 @@ describe('metalsmith flexible shortcodes', function() {
             opts: {
                 shortcodes: {
                     'var': function(str, params, data) {
-                        for (var name in params) {
-                            return data[name];
-                        }
+                    	for (var i = 0; i< params.length; i++) {
+                    		return data[params[i]];
+                    	}
                     }
                 },
                 clean: true
@@ -113,9 +113,9 @@ describe('metalsmith flexible shortcodes', function() {
             opts: {
                 shortcodes: {
                     'var': function(str, params, data) {
-                        for (var name in params) {
-                            return data[name];
-                        }
+                        for (var i = 0; i< params.length; i++) {
+                    		return data[params[i]];
+                    	}
                     }
                 },
                 clean: true
@@ -126,5 +126,4 @@ describe('metalsmith flexible shortcodes', function() {
             done();
         });
     });
-
 });


### PR DESCRIPTION
Adding options which will pass custom open and close tags through to meta-shortcodes.

The reason for requesting this is the behaviour around markdown link syntax `[link](url)` and meta-shortcodes seems to behave in an unexpected way. 

Doing this allows overriding the tags to something that will not clash

Also fixed the failing tests which was raised in https://github.com/RobinThrift/metalsmith-flexible-shortcodes/issues/7